### PR TITLE
Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/grails-encoder/src/main/groovy/org/grails/encoder/impl/BasicJSONEncoder.java
+++ b/grails-encoder/src/main/groovy/org/grails/encoder/impl/BasicJSONEncoder.java
@@ -96,7 +96,7 @@ public class BasicJSONEncoder extends AbstractCharReplacementEncoder {
         if(o == null) {
             return null;
         }        
-        if(o instanceof CharSequence || (o != null && ClassUtils.isPrimitiveOrWrapper(o.getClass())) ) {
+        if(o instanceof CharSequence || ClassUtils.isPrimitiveOrWrapper(o.getClass()) ) {
             return super.encode(o);
         } else {
             return encodeAsJsonObject(o);            

--- a/grails-encoder/src/main/groovy/org/grails/encoder/impl/BasicXMLEncoder.java
+++ b/grails-encoder/src/main/groovy/org/grails/encoder/impl/BasicXMLEncoder.java
@@ -93,7 +93,7 @@ public class BasicXMLEncoder extends AbstractCharReplacementEncoder {
         if(o == null) {
             return null;
         }
-        if(o instanceof CharSequence || (o != null && ClassUtils.isPrimitiveOrWrapper(o.getClass()))) {
+        if(o instanceof CharSequence || ClassUtils.isPrimitiveOrWrapper(o.getClass())) {
             return doCharReplacementEncoding(o);
         } else {
             return encodeAsXmlObject(o);            

--- a/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -258,20 +258,18 @@ public abstract class GroovyPage extends Script {
             return value;
         }
 
-        if (value == null) {
-            value = gspTagLibraryLookup != null ? gspTagLibraryLookup.lookupNamespaceDispatcher(property) : null;
-            if (value == null && jspTags.containsKey(property)) {
-                TagLibraryResolver tagResolver = getTagLibraryResolver();
+        value = gspTagLibraryLookup != null ? gspTagLibraryLookup.lookupNamespaceDispatcher(property) : null;
+        if (value == null && jspTags.containsKey(property)) {
+            TagLibraryResolver tagResolver = getTagLibraryResolver();
 
-                String uri = (String) jspTags.get(property);
-                if (uri != null) {
-                    value = tagResolver.resolveTagLibrary(uri);
-                }
+            String uri = (String) jspTags.get(property);
+            if (uri != null) {
+                value = tagResolver.resolveTagLibrary(uri);
             }
-            if (value != null) {
-                // cache lookup for next execution
-                setVariableDirectly(property, value);
-            }
+        }
+        if (value != null) {
+            // cache lookup for next execution
+            setVariableDirectly(property, value);
         }
 
         return value;

--- a/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPageWritable.java
@@ -111,10 +111,8 @@ public class GroovyPageWritable implements Writable {
             if (hasRequest) {
                 parentBinding = outputContext.getBinding();
                 if (parentBinding == null) {
-                    if (outputContext != null) {
-                        parentBinding = outputContext.createAndRegisterRootBinding();
-                        newParentCreated = true;
-                    }
+                    parentBinding = outputContext.createAndRegisterRootBinding();
+                    newParentCreated = true;
                 }
             }
 

--- a/grails-plugin-testing/src/main/groovy/org/grails/compiler/injection/test/TestMixinTransformation.java
+++ b/grails-plugin-testing/src/main/groovy/org/grails/compiler/injection/test/TestMixinTransformation.java
@@ -291,9 +291,7 @@ public class TestMixinTransformation implements ASTTransformation{
             FieldNode spockSharedRuleFieldNode = classNode.addField(RULE_FIELD_NAME_BASE + "SharedClassRule", Modifier.PUBLIC, ClassHelper.make(TestRule.class), new FieldExpression(staticRuleFieldNode));
             spockSharedRuleFieldNode.addAnnotation(classRuleAnnotation);
             spockSharedRuleFieldNode.addAnnotation(new AnnotationNode(ClassHelper.make(Shared.class)));
-            if(spockTest) {
-                addSpockFieldMetadata(spockSharedRuleFieldNode, 0);
-            }
+            addSpockFieldMetadata(spockSharedRuleFieldNode, 0);
         } else {
             staticRuleFieldNode.setModifiers(Modifier.PUBLIC | Modifier.STATIC);
             staticRuleFieldNode.addAnnotation(classRuleAnnotation);

--- a/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/GroovyPageLayoutFinder.java
+++ b/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/GroovyPageLayoutFinder.java
@@ -212,7 +212,7 @@ public class GroovyPageLayoutFinder implements ApplicationListener<ContextRefres
             d = getNamedDecorator(request, layoutProperty.toString());
         }
         else {
-            if (d == null && !GrailsStringUtils.isBlank(actionUri)) {
+            if (!GrailsStringUtils.isBlank(actionUri)) {
                 d = getNamedDecorator(request, actionUri.substring(1), true);
             }
 

--- a/grails-web-taglib/src/main/groovy/org/grails/compiler/web/taglib/TagLibraryTransformer.java
+++ b/grails-web-taglib/src/main/groovy/org/grails/compiler/web/taglib/TagLibraryTransformer.java
@@ -172,7 +172,7 @@ public class TagLibraryTransformer implements GrailsArtefactClassInjector, Annot
                 classNode.addMethod(new MethodNode(tagName, Modifier.PUBLIC,GrailsASTUtils.OBJECT_CLASS_NODE, MAP_CLOSURE_PARAMETERS, null, methodBody));
             }
         }
-        else if (includeAttrs && !includeBody) {
+        else if (includeAttrs) {
             if (!methodExists(classNode, tagName, MAP_PARAMETERS)) {
                 classNode.addMethod(new MethodNode(tagName, Modifier.PUBLIC,GrailsASTUtils.OBJECT_CLASS_NODE, MAP_PARAMETERS, null, methodBody));
             }


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule squid:S2583 - Conditions should not unconditionally evaluate to ""TRUE"" or to ""FALSE""
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2583
Please let me know if you have any questions.
Kirill Vlasov"