### PR TITLE
Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET

### DIFF
--- a/grails-core/src/main/groovy/grails/util/AbstractTypeConvertingMap.java
+++ b/grails-core/src/main/groovy/grails/util/AbstractTypeConvertingMap.java
@@ -426,7 +426,7 @@ public abstract class AbstractTypeConvertingMap extends GroovyObjectSupport impl
     public List getList(String name) {
         Object paramValues = get(name);
         if (paramValues == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         if (paramValues.getClass().isArray()) {
             return Arrays.asList((Object[])paramValues);

--- a/grails-core/src/main/groovy/org/grails/core/cfg/DeprecatedGrailsConfig.java
+++ b/grails-core/src/main/groovy/org/grails/core/cfg/DeprecatedGrailsConfig.java
@@ -183,7 +183,7 @@ public class DeprecatedGrailsConfig implements Settings {
     @SuppressWarnings("rawtypes")
     public Map getFlatConfig() {
         if(grailsApplication == null) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
         return grailsApplication.getFlatConfig();
     }

--- a/grails-core/src/main/groovy/org/grails/core/support/GrailsDomainConfigurationUtil.java
+++ b/grails-core/src/main/groovy/org/grails/core/support/GrailsDomainConfigurationUtil.java
@@ -216,7 +216,7 @@ public class GrailsDomainConfigurationUtil {
 
         Map<?, ?> associationMap = cpf.getPropertyValue(GrailsDomainClassProperty.HAS_MANY, Map.class);
         if (associationMap == null) {
-            associationMap = Collections.EMPTY_MAP;
+            associationMap = Collections.emptyMap();
         }
         return associationMap;
     }
@@ -232,7 +232,7 @@ public class GrailsDomainConfigurationUtil {
 
         Map<?, ?> mappedByMap = cpf.getPropertyValue(GrailsDomainClassProperty.MAPPED_BY, Map.class);
         if (mappedByMap == null) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
         return mappedByMap;
     }

--- a/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -78,7 +78,7 @@ public abstract class GroovyPage extends Script {
     private static final String BINDING = "binding";
     private static final String BLANK_STRING = "";
     @SuppressWarnings("rawtypes")
-    private Map jspTags = Collections.EMPTY_MAP;
+    private Map jspTags = Collections.emptyMap();
     private TagLibraryResolver jspTagLibraryResolver;
     private TagLibraryLookup gspTagLibraryLookup;
     private String[] htmlParts;

--- a/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPageMetaInfo.java
@@ -63,7 +63,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
     private int[] lineNumbers;
     private String[] htmlParts;
     @SuppressWarnings("rawtypes")
-    private Map jspTags = Collections.EMPTY_MAP;
+    private Map jspTags = Collections.emptyMap();
     private GroovyPagesException compilationException;
     private Encoder expressionEncoder;
     private Encoder staticEncoder;
@@ -297,7 +297,7 @@ public class GroovyPageMetaInfo implements GrailsApplicationAware {
 
     @SuppressWarnings("rawtypes")
     public void setJspTags(Map jspTags) {
-        this.jspTags = jspTags != null ? jspTags : Collections.EMPTY_MAP;
+        this.jspTags = jspTags != null ? jspTags : Collections.emptyMap();
     }
 
     @SuppressWarnings("rawtypes")

--- a/grails-spring/src/main/groovy/org/grails/spring/DefaultBeanConfiguration.java
+++ b/grails-spring/src/main/groovy/org/grails/spring/DefaultBeanConfiguration.java
@@ -152,7 +152,7 @@ public class DefaultBeanConfiguration extends GroovyObjectSupport implements Bea
     private String name;
     private boolean singleton = true;
     private AbstractBeanDefinition definition;
-    private Collection<?> constructorArgs = Collections.EMPTY_LIST;
+    private Collection<?> constructorArgs = Collections.emptyList();
     private BeanWrapper wrapper;
 
     public DefaultBeanConfiguration(String name, Class<?> clazz) {
@@ -161,12 +161,12 @@ public class DefaultBeanConfiguration extends GroovyObjectSupport implements Bea
     }
 
     public DefaultBeanConfiguration(String name, Class<?> clazz, boolean prototype) {
-        this(name,clazz,Collections.EMPTY_LIST);
+        this(name,clazz, Collections.emptyList());
         singleton = !prototype;
     }
 
     public DefaultBeanConfiguration(String name) {
-        this(name,null,Collections.EMPTY_LIST);
+        this(name,null, Collections.emptyList());
     }
 
     public DefaultBeanConfiguration(Class<?> clazz2) {
@@ -180,7 +180,7 @@ public class DefaultBeanConfiguration extends GroovyObjectSupport implements Bea
     }
 
     public DefaultBeanConfiguration(String name2, boolean prototype) {
-        this(name2,null,Collections.EMPTY_LIST);
+        this(name2,null, Collections.emptyList());
         singleton = !prototype;
     }
 

--- a/grails-validation/src/main/groovy/grails/validation/ConstrainedProperty.java
+++ b/grails-validation/src/main/groovy/grails/validation/ConstrainedProperty.java
@@ -229,7 +229,7 @@ public class ConstrainedProperty implements Constrained {
     private String widget; // the widget to use to render the property
     private boolean password; // whether the property is a password
     @SuppressWarnings("rawtypes")
-    private Map attributes = Collections.EMPTY_MAP; // a map of attributes of property
+    private Map attributes = Collections.emptyMap(); // a map of attributes of property
     protected MessageSource messageSource;
     private Map<String, Object> metaConstraints = new HashMap<String, Object>();
 

--- a/grails-validation/src/main/groovy/org/grails/validation/ConstrainedPropertyBuilder.java
+++ b/grails-validation/src/main/groovy/org/grails/validation/ConstrainedPropertyBuilder.java
@@ -239,12 +239,12 @@ public class ConstrainedPropertyBuilder extends BuilderSupport {
 
     @Override
     protected Object createNode(Object name) {
-        return createNode(name, Collections.EMPTY_MAP);
+        return createNode(name, Collections.emptyMap());
     }
 
     @Override
     protected Object createNode(Object name, Object value) {
-        return createNode(name,Collections.EMPTY_MAP,value);
+        return createNode(name, Collections.emptyMap(),value);
     }
 
     public Map<String, Constrained> getConstrainedProperties() {

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/DataBindingUtils.java
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/DataBindingUtils.java
@@ -109,11 +109,11 @@ public class DataBindingUtils {
      * @return A BindingResult or null if it wasn't successful
      */
     public static BindingResult bindObjectToInstance(Object object, Object source) {
-        return bindObjectToInstance(object, source, getBindingIncludeList(object), Collections.EMPTY_LIST, null);
+        return bindObjectToInstance(object, source, getBindingIncludeList(object), Collections.emptyList(), null);
     }
 
     private static List getBindingIncludeList(final Object object) {
-        List includeList = Collections.EMPTY_LIST;
+        List includeList = Collections.emptyList();
         try {
             final Class<? extends Object> objectClass = object.getClass();
             if (CLASS_TO_BINDING_INCLUDE_LIST.containsKey(objectClass)) {
@@ -149,7 +149,7 @@ public class DataBindingUtils {
      * @return A BindingResult or null if it wasn't successful
      */
     public static BindingResult bindObjectToDomainInstance(GrailsDomainClass domain, Object object, Object source) {
-        return bindObjectToDomainInstance(domain,object, source, getBindingIncludeList(object), Collections.EMPTY_LIST, null);
+        return bindObjectToDomainInstance(domain,object, source, getBindingIncludeList(object), Collections.emptyList(), null);
     }
 
     /**
@@ -171,7 +171,7 @@ public class DataBindingUtils {
         final List<DataBindingSource> dataBindingSources = collectionBindingSource.getDataBindingSources();
         for(final DataBindingSource dataBindingSource : dataBindingSources) {
             final T newObject = targetType.newInstance();
-            bindObjectToDomainInstance(domain, newObject, dataBindingSource, getBindingIncludeList(newObject), Collections.EMPTY_LIST, null);
+            bindObjectToDomainInstance(domain, newObject, dataBindingSource, getBindingIncludeList(newObject), Collections.emptyList(), null);
             collectionToPopulate.add(newObject);
         }
     }

--- a/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/SpringMVCViewDecorator.java
+++ b/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/SpringMVCViewDecorator.java
@@ -46,7 +46,7 @@ public class SpringMVCViewDecorator extends DefaultDecorator implements com.open
     private View view;
 
     public SpringMVCViewDecorator(String name, View view) {
-        super(name, (view instanceof AbstractUrlBasedView) ? ((AbstractUrlBasedView)view).getUrl() : view.toString(), Collections.EMPTY_MAP);
+        super(name, (view instanceof AbstractUrlBasedView) ? ((AbstractUrlBasedView)view).getUrl() : view.toString(), Collections.emptyMap());
         this.view = view;
     }
 

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMapping.java
@@ -47,7 +47,7 @@ public abstract class AbstractUrlMapping implements UrlMapping {
     protected ServletContext servletContext;
     protected GrailsApplication grailsApplication;
     @SuppressWarnings("rawtypes")
-    protected Map parameterValues = Collections.EMPTY_MAP;
+    protected Map parameterValues = Collections.emptyMap();
     protected boolean parseRequest;
     protected String mappingName;
     protected String httpMethod = ANY_HTTP_METHOD;

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMappingInfo.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMappingInfo.java
@@ -41,7 +41,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class AbstractUrlMappingInfo implements UrlMappingInfo {
 
-    private Map<String, Object> params = Collections.EMPTY_MAP;
+    private Map<String, Object> params = Collections.emptyMap();
 
     public Map<String, Object> getParams() {
         return params;

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlCreator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlCreator.java
@@ -57,7 +57,7 @@ public class DefaultUrlCreator implements UrlCreator {
     }
 
     public String createURL(Map parameterValues, String encoding) {
-        if (parameterValues == null) parameterValues = Collections.EMPTY_MAP;
+        if (parameterValues == null) parameterValues = Collections.emptyMap();
         GrailsWebRequest webRequest = (GrailsWebRequest) RequestContextHolder.getRequestAttributes();
         return createURLWithWebRequest(parameterValues, webRequest, true);
     }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
@@ -587,7 +587,7 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
                         if (!hasParent) {
                             urlDefiningMode = false;
                         }
-                        args = args != null && args.length > 0 ? args : new Object[]{Collections.EMPTY_MAP};
+                        args = args != null && args.length > 0 ? args : new Object[]{Collections.emptyMap()};
                         if (args[0] instanceof Closure) {
                             UrlMappingData urlData = createUrlMappingData(mappedURI, isResponseCode);
 
@@ -623,7 +623,7 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
 
                             if (binding != null) {
                                 Map bindingVariables = variables;
-                                Object parse = getParseRequest(Collections.EMPTY_MAP, bindingVariables);
+                                Object parse = getParseRequest(Collections.emptyMap(), bindingVariables);
                                 if (parse instanceof Boolean) {
                                     urlMapping.setParseRequest((Boolean) parse);
                                 }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingInfo.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingInfo.java
@@ -128,13 +128,13 @@ public class DefaultUrlMappingInfo extends AbstractUrlMappingInfo {
     }
 
     public DefaultUrlMappingInfo(Object uri, UrlMappingData data, GrailsApplication grailsApplication) {
-        this(Collections.EMPTY_MAP, data, grailsApplication);
+        this(Collections.emptyMap(), data, grailsApplication);
         this.uri = uri;
         Assert.notNull(uri, "Argument [uri] cannot be null or blank");
     }
 
     public DefaultUrlMappingInfo(Object uri,String httpMethod, UrlMappingData data, GrailsApplication grailsApplication) {
-        this(Collections.EMPTY_MAP, data, grailsApplication);
+        this(Collections.emptyMap(), data, grailsApplication);
         this.uri = uri;
         this.httpMethod = httpMethod;
         Assert.notNull(uri, "Argument [uri] cannot be null or blank");

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingsHolder.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingsHolder.java
@@ -230,7 +230,7 @@ public class DefaultUrlMappingsHolder implements UrlMappings, org.codehaus.groov
 
     @Override
     public UrlCreator getReverseMapping(String controller, String action, String namespace, String pluginName, String httpMethod, String version, Map params) {
-        if (params == null) params = Collections.EMPTY_MAP;
+        if (params == null) params = Collections.emptyMap();
 
         if (urlCreatorCache != null) {
             UrlCreatorCache.ReverseMappingKey key=urlCreatorCache.createKey(controller, action, namespace, pluginName, httpMethod,params);
@@ -265,7 +265,7 @@ public class DefaultUrlMappingsHolder implements UrlMappings, org.codehaus.groov
 
     @Override
     public UrlCreator getReverseMappingNoDefault(String controller, String action, String namespace, String pluginName, String httpMethod, String version, Map params) {
-        if (params == null) params = Collections.EMPTY_MAP;
+        if (params == null) params = Collections.emptyMap();
 
         if (urlCreatorCache != null) {
             UrlCreatorCache.ReverseMappingKey key=urlCreatorCache.createKey(controller, action, namespace, pluginName, httpMethod, params);
@@ -306,7 +306,7 @@ public class DefaultUrlMappingsHolder implements UrlMappings, org.codehaus.groov
             }
         }
         if (mapping == null || (mapping instanceof ResponseCodeUrlMapping)) {
-            UrlMappingKey lookupKey = new UrlMappingKey(controller, action, namespace, pluginName, httpMethod,version, Collections.EMPTY_SET);
+            UrlMappingKey lookupKey = new UrlMappingKey(controller, action, namespace, pluginName, httpMethod,version, Collections.<String>emptySet());
             mapping = mappingsLookup.get(lookupKey);
             if (mapping == null) {
                 lookupKey.httpMethod = UrlMapping.ANY_HTTP_METHOD;
@@ -643,7 +643,7 @@ public class DefaultUrlMappingsHolder implements UrlMappings, org.codehaus.groov
         String pluginName;
         String httpMethod;
         String version;
-        Set<String> paramNames = Collections.EMPTY_SET;
+        Set<String> paramNames = Collections.emptySet();
 
         public UrlMappingKey(String controller, String action, String namespace, String pluginName, String httpMethod, String version,Set<String> paramNames) {
             this.controller = controller;

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -321,7 +321,7 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                 contextPath = webRequest.getAttributes().getApplicationUri(webRequest.getCurrentRequest());
             }
         }
-        if (paramValues == null) paramValues = Collections.EMPTY_MAP;
+        if (paramValues == null) paramValues = Collections.emptyMap();
         StringBuilder uri = new StringBuilder(contextPath);
         Set usedParams = new HashSet();
 

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/ResponseCodeUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/ResponseCodeUrlMapping.java
@@ -39,7 +39,7 @@ public class ResponseCodeUrlMapping extends AbstractUrlMapping {
 
     private final ResponseCodeMappingData urlData;
     private final ConstrainedProperty[] constraints = new ConstrainedProperty[0];
-    private Map parameterValues = Collections.EMPTY_MAP;
+    private Map parameterValues = Collections.emptyMap();
     private Class<?> exceptionType;
 
     public ResponseCodeUrlMapping(UrlMappingData urlData, Object controllerName, Object actionName, Object namespace, Object pluginName, Object viewName, ConstrainedProperty[] constraints, GrailsApplication grailsApplication) {

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
@@ -134,7 +134,7 @@ public class UrlMappingUtils {
      */
     public static String forwardRequestForUrlMappingInfo(HttpServletRequest request,
             HttpServletResponse response, UrlMappingInfo info) throws ServletException, IOException {
-        return forwardRequestForUrlMappingInfo(request, response, info, Collections.EMPTY_MAP);
+        return forwardRequestForUrlMappingInfo(request, response, info, Collections.emptyMap());
     }
 
     /**


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1596
Please let me know if you have any questions.
Kirill Vlasov"